### PR TITLE
Set fallback value for number of tasks

### DIFF
--- a/MMM-GoogleTasks.js
+++ b/MMM-GoogleTasks.js
@@ -84,7 +84,10 @@ Module.register("MMM-GoogleTasks",{
 		wrapper.className = "container ";
 		wrapper.className += this.config.tableClass;
 
-		 var numTasks = Object.keys(this.tasks).length;
+		var numTasks = 0;
+		if(this.tasks) {
+			var numTasks = Object.keys(this.tasks).length;
+		}
 
 		if (!this.tasks) {
 			wrapper.innerHTML = (this.loaded) ? "EMPTY" : "LOADING";

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Displays tasks from Google Tasks App
 ## Installation
 To install the module, use your terminal to:
 1. Navigate to your MagicMirror's modules folder. If you are using the default installation directory, use the command:<br />`cd ~/MagicMirror/modules`
-2. Clone the module:<br />`git clone https://github.com/jgauth/MMM-GoogleTasks.git`
+2. Clone the module:<br />`git clone https://github.com/jayked/MMM-GoogleTasks.git`
 3. Install Google API:<br />`npm install googleapis`
 
 ## Authentication Setup


### PR DESCRIPTION
This sets a default for the `numTasks` variable, in the `getDom` method, and overwrites it when tasks are set and available.
By doing this the `Cannot convert undefined or null to object` console error will be prevented.

It is possible that #5 could be closed upon merging this pull request, because it made the [MMM-Remote-Control module](https://github.com/Jopyth/MMM-Remote-Control) work again.