### PR TITLE
Set fallback value for number of tasks

### DIFF
--- a/MMM-GoogleTasks.js
+++ b/MMM-GoogleTasks.js
@@ -84,7 +84,10 @@ Module.register("MMM-GoogleTasks",{
 		wrapper.className = "container ";
 		wrapper.className += this.config.tableClass;
 
-		 var numTasks = Object.keys(this.tasks).length;
+		var numTasks = 0;
+		if(this.tasks) {
+			var numTasks = Object.keys(this.tasks).length;
+		}
 
 		if (!this.tasks) {
 			wrapper.innerHTML = (this.loaded) ? "EMPTY" : "LOADING";


### PR DESCRIPTION
This sets a default for the `numTasks` variable, in the `getDom` method, and overwrites it when tasks are set and available.
By doing this the `Cannot convert undefined or null to object` console error will be prevented.

It is possible that #5 could be closed upon merging this pull request, because it made the [MMM-Remote-Control module](https://github.com/Jopyth/MMM-Remote-Control) work again.