### PR TITLE
Provide default value to tasks.

### DIFF
--- a/MMM-GoogleTasks.js
+++ b/MMM-GoogleTasks.js
@@ -34,7 +34,7 @@ Module.register("MMM-GoogleTasks",{
 	start: function() {
 
 		Log.info("Starting module: " + this.name);
-		this.tasks;
+		this.tasks = {};
 		this.loaded = false;
 		if(!this.config.listID) {
 			Log.log("config listID required");


### PR DESCRIPTION
Based on the discussion and the post by [sdetweil](https://forum.magicmirror.builders/topic/9408/mmm-googletasks-not-compatible-with-mmm-pages-mmm-carousel-or-mmm-modulescheduler) on the forum, I made the provided change and tested with ONLY `MMM-pages` module.